### PR TITLE
Build index.md in GitHub Action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,10 +6,16 @@ on:
     tags:
       -'*'
 
-name: pkgdown
+name: build-pkgdown-site
 
+##
+## This job:
+##   - re-renders the index.md file from index.Rmd, 
+##   - builds pgkdown website
+##   - deploys pgkdown website
+##
 jobs:
-  pkgdown:
+  build-pkgdown-site:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +45,9 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           install.packages("pkgdown", type = "binary")
         shell: Rscript {0}
+
+      - name: Render index.Rmd (landing page for website)
+        run: Rscript -e 'rmarkdown::render("index.Rmd", "md_document")'
 
       - name: Install package
         run: R CMD INSTALL .


### PR DESCRIPTION
This pull request removes the large-ish index.md file from the repo. This file is large because it contains a demo NGCHM and is the landing page for the pkgdown website. A step is added to render index.md in the GitHub Action for building and deploying the pkgdown website.