### PR TITLE
Update vignettes for BRCA demo data

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -1480,7 +1480,7 @@ chmLabel <- function (x) {
 #' @export
 #'
 #' @examples
-#' chmColorMap (chmNewDataLayer('New layer', TCGA.GBM.EXPR[1:3,1:3))
+#' chmColorMap (chmNewDataLayer('New layer', TCGA.BRCA.ExpressionData[1:3,1:3]))
 #'
 #' @seealso [chmNewColorMap]
 #'
@@ -1504,7 +1504,7 @@ chmColorMap <- function (x) {
 #' @export
 #'
 #' @examples
-#' chmColorMap (chmNewDataLayer('New layer', TCGA.GBM.EXPR[1:3,1:3]), chmNewColormap (c(2,14));
+#' chmColorMap (chmNewDataLayer('New layer', TCGA.BRCA.ExpressionData[1:3,1:3]), chmNewColormap (c(2,14));
 #'
 #' @seealso [chmColorMap]
 #'
@@ -1529,7 +1529,7 @@ chmColorMap <- function (x) {
 #' @export
 #'
 #' @examples
-#' chmColors (chmNewDataLayer('New Layer', TCGA.GBM.EXPR[1:50,1:50))
+#' chmColors (chmNewDataLayer('New Layer', TCGA.BRCA.ExpressionData[1:50,1:50))
 #'
 #' @seealso [ngchm-class]
 #'
@@ -3522,9 +3522,9 @@ writeBinLines <- function(text, con) {
 #' matrix passed to [Rtsne::Rtsne()].
 #'
 #' @examples
-#' rtc <- Rtsne::Rtsne(t(TCGA.GBM.EXPR));
-#' hm <- chmNew ("gbm", TCGA.GBM.EXPR);
-#' hm <- chmAddTSNE(hm, "column", rtc, colnames(TCGA.GBM.EXPR));
+#' rtc <- Rtsne::Rtsne(t(TCGA.BRCA.ExpressionData));
+#' hm <- chmNew ("brca", TCGA.BRCA.ExpressionData);
+#' hm <- chmAddTSNE(hm, "column", rtc, colnames(TCGA.BRCA.ExpressionData));
 #'
 #' @export
 #'
@@ -3569,8 +3569,8 @@ chmAddTSNE <- function (hm, axis, tsne, pointIds, basename = "TSNE") {
 #' parameter basename (default "PC") and N ranges from 1 to the number of added covariate bars.
 #'
 #' @examples
-#' prc <- prcomp(TCGA.GBM.EXPR);
-#' hm <- chmNew ("gbm", TCGA.GBM.EXPR);
+#' prc <- prcomp(TCGA.BRCA.ExpressionData);
+#' hm <- chmNew ("brca", TCGA.BRCA.ExpressionData);
 #' hm <- chmAddPCA(hm, "column", prc);
 #'
 #' @export
@@ -3617,8 +3617,8 @@ chmAddPCA <- function (hm, axis, prc, basename = "PC", ndim=2) {
 #' added covariate bars.
 #'
 #' @examples
-#' umc <- umap::umap(t(TCGA.GBM.EXPR));
-#' hm <- chmNew ("gbm", TCGA.GBM.EXPR);
+#' umc <- umap::umap(t(TCGA.BRCA.ExpressionData));
+#' hm <- chmNew ("brca", TCGA.BRCA.ExpressionData);
 #' hm <- chmAddUMAP(hm, "column", umc);
 #'
 #' @export
@@ -3667,9 +3667,9 @@ chmAddUMAP <- function (hm, axis, umap, basename = "UMAP") {
 #' matrix passed to [uwot::umap()].
 #'
 #' @examples
-#' umc <- uwot::umap(t(TCGA.GBM.EXPR));
-#' hm <- chmNew ("gbm", TCGA.GBM.EXPR);
-#' hm <- chmAddUWOT(hm, "column", umc, colnames(TCGA.GBM.EXPR));
+#' umc <- uwot::umap(t(TCGA.BRCA.ExpressionData));
+#' hm <- chmNew ("brca", TCGA.BRCA.ExpressionData);
+#' hm <- chmAddUWOT(hm, "column", umc, colnames(TCGA.BRCA.ExpressionData));
 #'
 #' @export
 #'

--- a/R/package.R
+++ b/R/package.R
@@ -29,10 +29,10 @@
 #' @aliases NGCHM-package
 #'
 #' @examples
-#' data(TCGA.GBM.EXPR)
-#' chm1 <- chmNew('gbm', TCGA.GBM.EXPR[1:50,1:50], rowAxisType='bio.gene.hugo', colAxisType='bio.tcga.barcode.sample.vial.portion.analyte.aliquot');
-#'\dontrun{chmExportToFile(chm1, 'gbm.ngchm');
-#' chmExportToPDF(chm1, 'gbm.pdf');
+#' data(TCGA.BRCA.ExpressionData)
+#' chm1 <- chmNew('brca', TCGA.BRCA.ExpressionData[1:50,1:50], rowAxisType='bio.gene.hugo', colAxisType='bio.tcga.barcode.sample.vial.portion.analyte.aliquot');
+#'\dontrun{chmExportToFile(chm1, 'brca.ngchm');
+#' chmExportToPDF(chm1, 'brca.pdf');
 #'}
 #'
 #' mat <- matrix(rnorm(100),nrow=10)
@@ -47,14 +47,14 @@ NULL
 #' Sample dataset containing RNA expression data from Affymetrix U133A chips
 #' for TCGA Glioblastoma Multiforme samples.
 #'
-#' @name TCGA.GBM.EXPR
+#' @name TCGA.BRCA.ExpressionData
 #' @docType data
 #' @keywords data
 #'
 #' @examples
-#' data(TCGA.GBM.EXPR)
+#' data(TCGA.BRCA.ExpressionData)
 #' sample.type <- 'bio.tcga.barcode.sample.vial.portion.analyte.aliquot'
-#' chm <- chmNew ('my-gbm-chm', TCGA.GBM.EXPR, rowAxisType='bio.gene.hugo',
+#' chm <- chmNew ('my-brca-chm', TCGA.BRCA.ExpressionData, rowAxisType='bio.gene.hugo',
 #'                 colAxisType=sample.type)
 #'\dontrun{
 #' chmMake ('my-server', chm)

--- a/index.Rmd
+++ b/index.Rmd
@@ -26,30 +26,30 @@ Our [YouTube Video](https://www.youtube.com/watch?v=DuObpGNpDhw) presents a brie
 Click [Start Here!](articles/create-a-ng-chm.html) in the main menu to learn how to create an NG-CHM like the one below.
 
 
-### NG-CHM of Glioblastoma Multiform (GBM) Data from The Cancer Genome Atlas (TCGA)
+### NG-CHM of Breast Cancer (BRCA) Data from The Cancer Genome Atlas (TCGA)
 
 ```{r, message=FALSE, warning=FALSE, echo=FALSE }
 library(NGCHMDemoData)
 library(NGCHMSupportFiles)
 library(NGCHM)
 colorMap1 <- chmNewColorMap(c(-2,0,2), c('mediumblue','snow','firebrick'))
-dataLayer1 <- chmNewDataLayer('Color Map 1', TCGA.GBM.ExpressionData, colorMap1)
+dataLayer1 <- chmNewDataLayer('Color Map 1', TCGA.BRCA.ExpressionData, colorMap1)
 colorMap2 <- chmNewColorMap(c(-2,0,2), c('#9933ff','#f0f0f0','#228B22'))
-dataLayer2 <- chmNewDataLayer('Color Map 2', TCGA.GBM.ExpressionData, colorMap2)
+dataLayer2 <- chmNewDataLayer('Color Map 2', TCGA.BRCA.ExpressionData, colorMap2)
 hm <- chmNew('NGCHM-R', dataLayer1, dataLayer2)
-covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.GBM.TP53MutationData)
+covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.BRCA.TP53MutationData)
 hm <- chmAddCovariateBar(hm, 'column', covariateBar)
 hm <- chmAddAxisType(hm, 'row', 'bio.gene.hugo')
 hm <- chmAddAxisType(hm, 'column', 'bio.tcga.barcode.sample.vial.portion.analyte.aliquot')
 ```
 
 ```{r, message=FALSE, warning=FALSE, echo=FALSE, results='hide' }
-chmExportToHTML(hm,'tcga-gbm-intro.html',overwrite=TRUE)
+chmExportToHTML(hm,'tcga-brca-intro.html',overwrite=TRUE)
 ```
 
 ```{r, message=FALSE, warning=FALSE, echo=FALSE }
 library('htmltools')
-filePath = paste(getwd(),'/tcga-gbm-intro.html',sep='')
+filePath = paste(getwd(),'/tcga-brca-intro.html',sep='')
 htmltools::includeHTML(filePath)
 ```
 

--- a/vignettes/adding-linkouts.Rmd
+++ b/vignettes/adding-linkouts.Rmd
@@ -23,7 +23,7 @@ The needed packages are loaded and a basic NG-CHM is constructed from the sample
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMDemoData)
 library(NGCHM)
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData)
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData)
 ```
 
 To add linkouts, the axis type is specified with `chmAddAxisType()`. For the demo data in this example, 
@@ -45,12 +45,12 @@ Here is the resulting NG-CHM:
 
 ```{r, echo=FALSE, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMSupportFiles)
-chmExportToHTML(hm,'tcga-gbm-with-linkouts.html')
+chmExportToHTML(hm,'tcga-brca-with-linkouts.html')
 ```
 
 ```{r, warning=FALSE, message=FALSE, echo=FALSE}
 library('htmltools')
-filePath = paste(getwd(),'/tcga-gbm-with-linkouts.html',sep='')
+filePath = paste(getwd(),'/tcga-brca-with-linkouts.html',sep='')
 htmltools::includeHTML(filePath)
 ```
 

--- a/vignettes/clustering-and-column-row-ordering.Rmd
+++ b/vignettes/clustering-and-column-row-ordering.Rmd
@@ -27,7 +27,7 @@ The following command produces a NG-CHM with rows sorted alphabetically and colu
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
 library(NGCHM)
 library(NGCHMDemoData)
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData, rowOrder=sort(rownames(TCGA.GBM.ExpressionData)), colOrder=colnames(TCGA.GBM.ExpressionData)[ sample.int(length(colnames(TCGA.GBM.ExpressionData))) ])
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData, rowOrder=sort(rownames(TCGA.BRCA.ExpressionData)), colOrder=colnames(TCGA.BRCA.ExpressionData)[ sample.int(length(colnames(TCGA.BRCA.ExpressionData))) ])
 ```
 
 ## Hierarchical Clustering Options
@@ -46,7 +46,7 @@ This example specifies a NG-CHM with hierarchical clustering using the Euclidean
 metric and complete linkage clustering algorithm for both rows and columns:
 
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData, rowDist='euclidean', colDist='euclidean', rowAgglom='complete', colAgglom='complete')
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData, rowDist='euclidean', colDist='euclidean', rowAgglom='complete', colAgglom='complete')
 ```
 
 ## Explicit Clustering
@@ -57,9 +57,9 @@ expression data, for both the rows and columns,
 and uses those clustering results to construct an NG-CHM.
 
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
-rowClust <- stats::hclust(dist(TCGA.GBM.ExpressionData))
-colClust <- stats::hclust(dist(t(TCGA.GBM.ExpressionData)))
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData, rowOrder=rowClust, colOrder=colClust)
+rowClust <- stats::hclust(dist(TCGA.BRCA.ExpressionData))
+colClust <- stats::hclust(dist(t(TCGA.BRCA.ExpressionData)))
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData, rowOrder=rowClust, colOrder=colClust)
 ```
 
 Similarly, an hclust object can be transformed into a dendrogram and used for the row and/or column
@@ -68,6 +68,6 @@ ordering. The example below uses the clutering results from above as dedrograms:
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
 rowDendrogram <- as.dendrogram(rowClust)
 colDendrogram <- as.dendrogram(colClust)
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData, rowOrder=rowDendrogram, colOrder=colDendrogram)
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData, rowOrder=rowDendrogram, colOrder=colDendrogram)
 ```
 

--- a/vignettes/continuous-color-maps-and-data-layers.Rmd
+++ b/vignettes/continuous-color-maps-and-data-layers.Rmd
@@ -22,7 +22,7 @@ NG-CHM from 2 data layers, each with its own custom color maps.
 ## Color Map (Continuous)
 
 Color maps are created with `chmNewColorMap()`. The first argument to this function
-is a list of breakpoints. For the demo data in TCGA.GBM.ExpressionData, most values are between
+is a list of breakpoints. For the demo data in TCGA.BRCA.ExpressionData, most values are between
 -2 and 2, so we set breakpoints at -2, 0, and 2. The second argument is a corresponding list of
 colors for those breakpoints. The colors can be specified by name for standard colors, or by hexadecimal code:
 
@@ -39,8 +39,8 @@ of the data layer. The second argument is the matrix of data, and the third argu
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMDemoData)
-dataLayer1 <- chmNewDataLayer('Color Map 1', TCGA.GBM.ExpressionData, colorMap1)
-dataLayer2 <- chmNewDataLayer('Color Map 2', TCGA.GBM.ExpressionData, colorMap2)
+dataLayer1 <- chmNewDataLayer('Color Map 1', TCGA.BRCA.ExpressionData, colorMap1)
+dataLayer2 <- chmNewDataLayer('Color Map 2', TCGA.BRCA.ExpressionData, colorMap2)
 ```
 
 ## Creating the NG-CHM
@@ -55,8 +55,8 @@ and export to a .ngchm or .html file:
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMSupportFiles)
-chmExportToFile(hm,'tcga-gbm-color-map.ngchm')
-chmExportToHTML(hm,'tcga-gbm-color-map.html')
+chmExportToFile(hm,'tcga-brca-color-map.ngchm')
+chmExportToHTML(hm,'tcga-brca-color-map.html')
 ```
 
 ## Resulting NG-CHM
@@ -66,7 +66,7 @@ between them.
 
 ```{r, message=FALSE}
 library('htmltools')
-filePath = paste(getwd(),'/tcga-gbm-color-map.html',sep='')
+filePath = paste(getwd(),'/tcga-brca-color-map.html',sep='')
 htmltools::includeHTML(filePath)
 ```
 

--- a/vignettes/continuous-color-maps-and-data-layers.Rmd
+++ b/vignettes/continuous-color-maps-and-data-layers.Rmd
@@ -17,20 +17,30 @@ knitr::opts_chunk$set(
 ```
 
 This vignette demonstrates how to specify the color maps and use data layers by creating a 
-NG-CHM from 2 data layers, each with its own custom color maps.
+NG-CHM from 2 data layers: a layer from the unadjusted data, and another from row-centering that data.
+Each layer will have its own custom color map.
 
 ## Color Map (Continuous)
 
 Color maps are created with `chmNewColorMap()`. The first argument to this function
-is a list of breakpoints. For the demo data in TCGA.BRCA.ExpressionData, most values are between
--2 and 2, so we set breakpoints at -2, 0, and 2. The second argument is a corresponding list of
-colors for those breakpoints. The colors can be specified by name for standard colors, or by hexadecimal code:
+is a list of breakpoints. For the TCGA.BRCA.ExpressionData demo data, reasonable breakpoints are
+6.4, 10, and 14. The second argument is a corresponding list of
+colors for those breakpoints. The colors can be specified by name for standard colors, or by hexadecimal code.
+
+For the unadjusted data color map:
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHM)
-colorMap1 <- chmNewColorMap(c(-2,0,2), c('mediumblue','snow','firebrick'))
-colorMap2 <- chmNewColorMap(c(-2,0,2), c('#9933ff','#f0f0f0','#228B22'))
+unadjustedColorMap <- chmNewColorMap(c(6.4,10,14), c('mediumblue','snow','firebrick'))
 ```
+
+For the second color map to be used with row-centered data, breakpoints are set at -2, 0, and 2. For 
+the purpose of illustration, the hexidecimal code is used for specifying the color.
+
+```{r, results='hide', message=FALSE, warning=FALSE}
+rowCenteredColorMap <- chmNewColorMap(c(-2,0,2), c('#9933ff','#f0f0f0','#228B22'))
+```
+
 
 ## Data Layers 
 
@@ -39,8 +49,9 @@ of the data layer. The second argument is the matrix of data, and the third argu
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMDemoData)
-dataLayer1 <- chmNewDataLayer('Color Map 1', TCGA.BRCA.ExpressionData, colorMap1)
-dataLayer2 <- chmNewDataLayer('Color Map 2', TCGA.BRCA.ExpressionData, colorMap2)
+unadjustedLayer <- chmNewDataLayer('Unadjusted', TCGA.BRCA.ExpressionData, unadjustedColorMap)
+rowCenteredData <- t(scale(t(TCGA.BRCA.ExpressionData)))
+rowCenteredLayer <- chmNewDataLayer('Row-Centered', rowCenteredData, rowCenteredColorMap)
 ```
 
 ## Creating the NG-CHM
@@ -48,15 +59,15 @@ dataLayer2 <- chmNewDataLayer('Color Map 2', TCGA.BRCA.ExpressionData, colorMap2
 We explicitly provide the two data layers created above to the `chmNew()` function:
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
-hm <- chmNew('Color Maps', dataLayer1, dataLayer2)
+hm <- chmNew('TCGA BRCA Expression', unadjustedLayer, rowCenteredLayer)
 ```
 
 and export to a .ngchm or .html file:
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMSupportFiles)
-chmExportToFile(hm,'tcga-brca-color-map.ngchm')
-chmExportToHTML(hm,'tcga-brca-color-map.html')
+chmExportToFile(hm,'tcga-brca-two-layers.ngchm')
+chmExportToHTML(hm,'tcga-brca-two-layers.html')
 ```
 
 ## Resulting NG-CHM
@@ -66,7 +77,7 @@ between them.
 
 ```{r, message=FALSE}
 library('htmltools')
-filePath = paste(getwd(),'/tcga-brca-color-map.html',sep='')
+filePath = paste(getwd(),'/tcga-brca-two-layers.html',sep='')
 htmltools::includeHTML(filePath)
 ```
 

--- a/vignettes/covariate-bars-and-discrete-color-maps.Rmd
+++ b/vignettes/covariate-bars-and-discrete-color-maps.Rmd
@@ -25,7 +25,7 @@ an initial NGCHM of the [demo expression data](create-a-ng-chm.html#sample-ng-ch
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMDemoData)
 library(NGCHM)
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData)
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData)
 ```
 
 A covariate bar can be created from the TP53 mutation vector using the `chmNewCovariate()` function.
@@ -33,7 +33,7 @@ The first argument is the desired name of the covariate bar, and the second is t
 of TP53 mutation demo data.
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
-covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.GBM.TP53MutationData)
+covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.BRCA.TP53MutationData)
 ```
 
 This covariate bar is then added to the NG-CHM created above with `chmAddCovariateBar()`:
@@ -46,8 +46,8 @@ This NG-CHM can be exported to either a .ngchm or .html file.
 
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
 library(NGCHMSupportFiles)
-chmExportToFile(hm,'tcga-gbm-covariates.ngchm')
-chmExportToHTML(hm,'tcga-gbm-covariates.html')
+chmExportToFile(hm,'tcga-brca-covariates.ngchm')
+chmExportToHTML(hm,'tcga-brca-covariates.html')
 ```
 
 ## Specify Covariate Bar Color Map
@@ -73,7 +73,7 @@ mutationColorMap <- chmNewColorMap(c("WT","MUT"),c("#6495ED","#f08080"))
 In the `chmNewCovariate()` function (also used above), an optional third argument is a color map:
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
-covariateBar <- chmNewCovariate('TP53 Mutation (other colors)',TCGA.GBM.TP53MutationData,mutationColorMap)
+covariateBar <- chmNewCovariate('TP53 Mutation (other colors)',TCGA.BRCA.TP53MutationData,mutationColorMap)
 ```
 
 Finally, this covariate bar can be added to the NG-CHM created above,
@@ -87,8 +87,8 @@ can be exported to either a .ngchm or .html file.
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 library(NGCHMSupportFiles)
-chmExportToFile(hm,'tcga-gbm-covariates.ngchm')
-chmExportToHTML(hm,'tcga-gbm-covariates.html')
+chmExportToFile(hm,'tcga-brca-covariates.ngchm')
+chmExportToHTML(hm,'tcga-brca-covariates.html')
 ```
 
 
@@ -99,7 +99,7 @@ with the cornflowerblue and lightcoral color map:
 
 ```{r, echo = FALSE}
 library('htmltools')
-filePath = paste(getwd(),'/tcga-gbm-covariates.html',sep='')
+filePath = paste(getwd(),'/tcga-brca-covariates.html',sep='')
 htmltools::includeHTML(filePath)
 ```
 

--- a/vignettes/create-a-ng-chm.Rmd
+++ b/vignettes/create-a-ng-chm.Rmd
@@ -31,14 +31,14 @@ and loaded into the current environment:
 library(NGCHMDemoData)
 ```
 
-The sample data includes a matrix of mRNA expression data, TCGA.GBM.Expression, containing 3540 genes (rows) and 169 samples 
-(columns) of Glioblastoma Multiforme data from The Cancer Genome Atlas (TCGA). **IMPORTANT: In order to be used as the basis for an NG-CHM, a matrix should have both
+The sample data includes a matrix of gene expression data, TCGA.BRCA.Expression, containing 3437 genes (rows) and 200 samples 
+(columns) of breast cancer data from The Cancer Genome Atlas (TCGA). **IMPORTANT: In order to be used as the basis for an NG-CHM, a matrix should have both
 rownames and colnames.** Here the rownames are genes and the colnames are TCGA sample identifiers:
 
-**GBM Expression Data Matrix:**
+**BRCA Expression Data Matrix:**
 
 ```{r}
-TCGA.GBM.ExpressionData[1:4,1:2]
+TCGA.BRCA.ExpressionData[1:4,1:2]
 ```
 
 The sample data also includes a vector of TP35 mutation status for the TCGA samples in the matrix. This 
@@ -50,7 +50,7 @@ a vector should have at least one name in common with the colnames of the matrix
 **TP53 Mutation Data Vector:**
 
 ```{r}
-TCGA.GBM.TP53MutationData[1:2]
+TCGA.BRCA.TP53MutationData[1:2]
 ```
 
 ## Creating a NG-CHM
@@ -59,13 +59,13 @@ Using the data loaded above, the `chmNew()` function can be used to create an NG
 
 ```{r, results='hide', message=FALSE, warning=FALSE }
 library(NGCHM)
-hm <- chmNew('tcga-gbm', TCGA.GBM.ExpressionData)
+hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData)
 ```
 
 A covariate bar of the TP53 mutation status can be added with:
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
-covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.GBM.TP53MutationData)
+covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.BRCA.TP53MutationData)
 hm <- chmAddCovariateBar(hm, 'column', covariateBar)
 ```
 
@@ -90,19 +90,19 @@ The NG-CHM can be exported as a stand-alone HTML file with the `chmExportToHTML(
 The first argument is the NG-CHM created above. The second argument is the desired filename.
 
 ```{r, results='hide', message=FALSE, warning=FALSE }
-chmExportToHTML(hm,'tcga-gbm.html')
+chmExportToHTML(hm,'tcga-brca.html')
 ```
 
-The file 'tcga-gbm.html' can be shared with collaborators and opened in a standard web browser.
+The file 'tcga-brca.html' can be shared with collaborators and opened in a standard web browser.
 
 Alternatively, .ngchm file can be created with the `chmExportToFile()` function.
 
 
 ```{r, eval=FALSE}
-chmExportToFile(hm,'tcga-gbm.ngchm')
+chmExportToFile(hm,'tcga-brca.ngchm')
 ```
 
-The file 'tcga-gbm.ngchm' can be opened in the [NG-CHM Viewer](https://www.ngchm.net/Downloads/ngChmApp.html). 
+The file 'tcga-brca.ngchm' can be opened in the [NG-CHM Viewer](https://www.ngchm.net/Downloads/ngChmApp.html). 
 **IMPORTANT: The filename must end with '.ngchm' to open in the NG-CHM Viewer**. 
 
 
@@ -112,7 +112,7 @@ The .html file can be embedded into RMarkdown via `htmltools::includeHTML()`:
 
 ```{r}
 library('htmltools')
-filePath = paste(getwd(),'/tcga-gbm.html',sep='')
+filePath = paste(getwd(),'/tcga-brca.html',sep='')
 htmltools::includeHTML(filePath)
 ```
 


### PR DESCRIPTION
The NGCHMDemoData package was updated with BRCA data (instead of GBM data) in version 0.0.10. This pull request updates the NGCHM-R package vignettes to use this new BRCA data.