### PR TITLE
Change 'caption' to 'description'

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -1348,7 +1348,7 @@ checkPropertyValue <- function (label, value) {
 #' @export
 #'
 #' @examples
-#' prop <- chmNewProperty ("chm.info.caption",
+#' prop <- chmNewProperty ("chm.info.description",
 #'                            "This is a nifty new CHM.")
 #'
 #' @seealso [ngchm-class]
@@ -1368,7 +1368,7 @@ chmNewProperty <- function (label, value) {
 #'
 #'        Well-known property labels used by the NG-CHM system include:
 #'
-#'        * "chm.info.caption"  A paragraph describing the NG-CHM's contents (set by user).
+#'        * "chm.info.description"  A paragraph describing the NG-CHM's contents (set by user).
 #'	  * "chm.info.built.time"  The date and time the NG-CHM was saved (set by system).
 #'
 #' @return A property value or NULL.
@@ -1376,7 +1376,7 @@ chmNewProperty <- function (label, value) {
 #' @export
 #'
 #' @examples
-#' chmProperty (hm, "chm.info.caption")
+#' chmProperty (hm, "chm.info.description")
 #'
 #' @seealso [ngchm-class]
 #'
@@ -1402,7 +1402,7 @@ chmProperty <- function (hm, label) {
 #' @export
 #'
 #' @examples
-#' chmProperty (hm, "chm.info.caption") <- "Nothing to see here";
+#' chmProperty (hm, "chm.info.description") <- "Nothing to see here";
 #'
 #' @seealso [ngchm-class]
 #'

--- a/index.Rmd
+++ b/index.Rmd
@@ -44,6 +44,7 @@ hm <- chmAddAxisType(hm, 'column', 'bio.tcga.barcode.sample.vial.portion.analyte
 ```
 
 ```{r, message=FALSE, warning=FALSE, echo=FALSE, results='hide' }
+chmProperty(hm, 'chm.info.description') <- 'TCGA BRCA expression data.<br><br>This data is from the NGCHM Demo Data R package, for use in NGCHM vignettes and examples.'
 chmExportToHTML(hm,'tcga-brca-intro.html',overwrite=TRUE)
 ```
 

--- a/man/chmNewProperty.Rd
+++ b/man/chmNewProperty.Rd
@@ -19,7 +19,7 @@ This function creates a new Property object for adding to
 a Next Generation Clustered Heat Map.
 }
 \examples{
-prop <- chmNewProperty ("chm.info.caption",
+prop <- chmNewProperty ("chm.info.description",
                            "This is a nifty new CHM.")
 
 }

--- a/man/chmProperty-set.Rd
+++ b/man/chmProperty-set.Rd
@@ -21,7 +21,7 @@ The modified NG-CHM object.
 Set the value of an NG-CHM property.
 }
 \examples{
-chmProperty (hm, "chm.info.caption") <- "Nothing to see here";
+chmProperty (hm, "chm.info.description") <- "Nothing to see here";
 
 }
 \seealso{

--- a/man/chmProperty.Rd
+++ b/man/chmProperty.Rd
@@ -12,7 +12,7 @@ chmProperty(hm, label)
 \item{label}{The name of the property to get.
 If no property with that name exists, return NULL.\preformatted{   Well-known property labels used by the NG-CHM system include:
 
-   * "chm.info.caption"  A paragraph describing the NG-CHM's contents (set by user).
+   * "chm.info.description"  A paragraph describing the NG-CHM's contents (set by user).
 }
 \itemize{
 \item "chm.info.built.time"  The date and time the NG-CHM was saved (set by system).
@@ -25,7 +25,7 @@ A property value or NULL.
 Get the value of an NG-CHM property.
 }
 \examples{
-chmProperty (hm, "chm.info.caption")
+chmProperty (hm, "chm.info.description")
 
 }
 \seealso{

--- a/vignettes/adding-linkouts.Rmd
+++ b/vignettes/adding-linkouts.Rmd
@@ -24,6 +24,7 @@ The needed packages are loaded and a basic NG-CHM is constructed from the sample
 library(NGCHMDemoData)
 library(NGCHM)
 hm <- chmNew('tcga-brca', TCGA.BRCA.ExpressionData)
+chmProperty(hm, 'chm.info.description') <- 'This NGCHM was created to demonstrate how to add linkouts.'
 ```
 
 To add linkouts, the axis type is specified with `chmAddAxisType()`. For the demo data in this example, 

--- a/vignettes/continuous-color-maps-and-data-layers.Rmd
+++ b/vignettes/continuous-color-maps-and-data-layers.Rmd
@@ -60,6 +60,7 @@ We explicitly provide the two data layers created above to the `chmNew()` functi
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 hm <- chmNew('TCGA BRCA Expression', unadjustedLayer, rowCenteredLayer)
+chmProperty(hm, 'chm.info.description') <- 'This NGCHM was created to demostrate how to add multiple data layers and color maps.'
 ```
 
 and export to a .ngchm or .html file:

--- a/vignettes/covariate-bars-and-discrete-color-maps.Rmd
+++ b/vignettes/covariate-bars-and-discrete-color-maps.Rmd
@@ -40,6 +40,7 @@ This covariate bar is then added to the NG-CHM created above with `chmAddCovaria
 
 ```{r, results='hide', message=FALSE, warning=FALSE}
 hm <- chmAddCovariateBar(hm, 'column', covariateBar)
+chmProperty(hm, 'chm.info.description') <- 'This NGCHM was created to demonstrate how to add covariate bars.'
 ```
 
 This NG-CHM can be exported to either a .ngchm or .html file.

--- a/vignettes/create-a-ng-chm.Rmd
+++ b/vignettes/create-a-ng-chm.Rmd
@@ -69,6 +69,13 @@ covariateBar <- chmNewCovariate('TP53 Mutation',TCGA.BRCA.TP53MutationData)
 hm <- chmAddCovariateBar(hm, 'column', covariateBar)
 ```
 
+A description of the NGCHM can be added with:
+
+```{r, results='hide', message=FALSE, warning=FALSE}
+chmProperty(hm, 'chm.info.description') <- 'TCGA BRCA expression data.<br><br>This data is from the NGCHM Demo Data R package, for use in NGCHM vignettes and examples.' 
+```
+
+This description can be viewed on the NGCHM by hovering the cursor over the 'Map Name' label.
 
 ## Export to File
 


### PR DESCRIPTION
With the goal of obtaining uniform language for users and developers, this pull request changes the 'chm.info.caption' property to 'chm.info.description'. 

In the NGCHM viewer, when users hover over the 'Map Name' label, this property is displayed with the label 'Description'.

**For the code in this PR to work as intended**, ShaidyMapGen.jar in the NGCHMSupportFiles must be updated with the code in the NGCHM Viewer pull request: https://github.com/MD-Anderson-Bioinformatics/NG-CHM/pull/100 