### PR TITLE
Actions bug fix: change order of steps

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -46,11 +46,11 @@ jobs:
           install.packages("pkgdown", type = "binary")
         shell: Rscript {0}
 
-      - name: Render index.Rmd (landing page for website)
-        run: Rscript -e 'rmarkdown::render("index.Rmd", "md_document")'
-
       - name: Install package
         run: R CMD INSTALL .
+
+      - name: Render index.Rmd (landing page for website)
+        run: Rscript -e 'rmarkdown::render("index.Rmd", "md_document")'
 
       - name: Deploy package
         run: |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,5 @@
 title: NGCHMR
-url: https://marohrdanz.github.io/NGCHM-R/
+url: https://md-anderson-bioinformatics.github.io/NGCHM-R/
 template:
   params:
     bootswatch: journal
@@ -65,7 +65,7 @@ navbar:
      - icon: fa-home
        href: index.html
      - icon: fa-github
-       href: https://github.com/marohrdanz.github.io/NGCHM-R/
+       href: https://github.com/md-anderson-bioinformatics.github.io/NGCHM-R/
 
 
   


### PR DESCRIPTION
This PR fixes a bug in the GitHub Action for building the pkgdown website.

The most recent build failed because the Action was trying to render index.Rmd before installing the NGCHM package. The rendered file, index.md, is the landing page for the website, but not a part of the R package. (This file is large, and so intentionally kept out of the R package; see c033c2832ff9ee00e950a2a1cc42cd5c3db21c67).

Some recent builds passed even with this incorrect ordering because R packages are cached between builds, so the NGCHM package was available when the Action attempted to render index.Rmd. However, if a cache is unused for 7 days GitHub automatically deletes it, and so the most recent build failed.

Also, the URL for the site is fixed--it was inadvertently set to my fork's URL.
