### PR TITLE
Use more precision for toJSON of singleElement

### DIFF
--- a/R/allClasses.R
+++ b/R/allClasses.R
@@ -965,7 +965,7 @@ getAxisData <- function (l, axis) {
 }
 setMethod(jsonlite:::asJSON, signature=c("singleElement"), definition=function(x,...) {
         stopifnot(length(x)==1);
-        toJSON (unbox (x[1]))
+        toJSON (unbox (x[1]), digits = I(7))
 });
 setMethod(jsonlite:::asJSON, signature=c("ngchmVersion2"), definition=function(x,...) {
     l <- s4ToList(x);


### PR DESCRIPTION
This pull request addresses an issue discovered with closely spaced color map breakpoints. For example: breakpoints 0.00019, 0.00022 will both be written to files in the shaidy repo as 0.0002. When the file is then read in by ShaidyMapGen.jar, the following error is generated: "HEAT MAP PARAMETER ERROR: Supplied Matrix Breakpoint values are not in ascending order", because `curValue <= preValue` evaluates as TRUE [line 114 in InputFile.java](https://github.com/MD-Anderson-Bioinformatics/NG-CHM/blob/e5610d3bd70ba63fe2ec29f1bb8f219235b35a39/NGCHM/src/mda/ngchm/datagenerator/InputFile.java#L104) in the [NGCHM viewer project](https://github.com/MD-Anderson-Bioinformatics/NG-CHM).

jsonlite::toJSON prints 4 by default (at least with R version 4.3.0 and jsonlite 1.8.4). This pull request uses scientific notation and 7 significant digits. From the documentation for `jsonlite::toJSON`:

```
  digits: max number of decimal digits to print for numeric values. Use
          ‘I()’ to specify significant digits. Use ‘NA’ for max
          precision.
```