### PR TITLE
Update Website Build Action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - master
     tags:
       -'*'
 
@@ -20,37 +19,19 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-r@v2
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("pkgdown", type = "binary")
-        shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
+          extra-packages: any::pkgdown, local::.
+          needs: website
 
       - name: Render index.Rmd (landing page for website)
-        run: Rscript -e 'rmarkdown::render("index.Rmd", "md_document")'
+        run: Rscript -e 'rmarkdown::render("index.Rmd", "md_document"); print(sessionInfo())'
 
       - name: Deploy package
         run: |

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -65,7 +65,7 @@ navbar:
      - icon: fa-home
        href: index.html
      - icon: fa-github
-       href: https://github.com/md-anderson-bioinformatics.github.io/NGCHM-R/
+       href: https://github.com/MD-Anderson-Bioinformatics/NGCHM-R/
 
 
   


### PR DESCRIPTION
Recall we have a GitHub action in this repo that uses [pkgdown](https://pkgdown.r-lib.org) to build and publish our documentation website (https://md-anderson-bioinformatics.github.io/NGCHM-R/) whenever code is merged into main.

Recent builds have failed (e.g., fdc3519bad51f1de2631d45d897fdcc2357edf90) due to outdated pieces of the workflow.

This pull request:

1. Updates those outdated pieces (file: .github/workflows/pkgdown.yaml)
2. Fixes an error in a the GitHub URL on the navigation bar of the website (file: _pkgdown.yml)

For reference, I tested these changes in my fork of this repo.