### PR TITLE
Pkgdown Updates

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,6 +25,8 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          extra-repositories: "https://md-anderson-bioinformatics.r-universe.dev"
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      JAVA_VERSION: 11
     steps:
       - uses: actions/checkout@v3
 
@@ -32,6 +33,12 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
+
+      - name: Set up JDK for java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: "${{ env.JAVA_VERSION }}"
+          distribution: 'temurin'
 
       - name: Render index.Rmd (landing page for website)
         run: Rscript -e 'rmarkdown::render("index.Rmd", "md_document"); print(sessionInfo())'

--- a/vignettes/Installation.Rmd
+++ b/vignettes/Installation.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ## System Requirements
 
 - R >= 3.5
-- Java >= 8
+- Java >= 11
 - git, tar, scp, ssh
   - Mac/Linux: typically installed by default
   - Windows: Cygwin or Windows Subsystem for Linux (Windows 10)

--- a/vignettes/Installation.Rmd
+++ b/vignettes/Installation.Rmd
@@ -34,13 +34,14 @@ knitr::opts_chunk$set(
 
 ## Install from GitHub
 
-The above-mentioned R packages can be installed from GitHub with
-[remotes](https://cran.r-project.org/package=remotes):
+The above-mentioned R packages can be installed from CRAN and
+[our R-Universe repository](https://md-anderson-bioinformatics.r-universe.dev/packages):
+
 
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
-remotes::install_github('MD-Anderson-Bioinformatics/tsvio')
-remotes::install_github('MD-Anderson-Bioinformatics/NGCHMSupportFiles', ref='main')
-remotes::install_github('MD-Anderson-Bioinformatics/NGCHM-R')
+install.packages('tsvio')
+install.packages('NGCHMSupportFiles', repos = c('https://md-anderson-bioinformatics.r-universe.dev', 'https://cloud.r-project.org'))
+install.packages('NGCHM', repos = c('https://md-anderson-bioinformatics.r-universe.dev', 'https://cloud.r-project.org'))
 ```
 
 ## Using the Docker Image

--- a/vignettes/create-a-ng-chm.Rmd
+++ b/vignettes/create-a-ng-chm.Rmd
@@ -19,10 +19,10 @@ This vignette demonstrates how to construct a simple NG-CHM, export it to a file
 ## Sample NG-CHM Data
 
 This vignette uses an additional package of demo data, [NGCHMDemoData](https://github.com/MD-Anderson-Bioinformatics/NGCHMDemoData), 
-which can be installed from GitHub with [remotes](https://cran.r-project.org/package=remotes):
+which can be installed from [our R-Universe repository](https://md-anderson-bioinformatics.r-universe.dev/packages):
 
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
-remotes::install_github('MD-Anderson-Bioinformatics/NGCHMDemoData', ref='main')
+install.packages('NGCHMDemoData', repos = c('https://md-anderson-bioinformatics.r-universe.dev', 'https://cloud.r-project.org'))
 ```
 
 and loaded into the current environment:


### PR DESCRIPTION
This pull request addresses issues building the [pkgdown website](https://md-anderson-bioinformatics.github.io/NGCHM-R/) from merging Pull Request #41 .

I used my fork of this repo to test and resolve the following issues:

1. Build failure: unable to install NGCHMDemoData and NGCHMSupportFiles
   - pkgdown does not recognize 'Additional_repositories' from the DESCRIPTION file
   - resolution: add the r-universe repo in the pgkdown workflow file (ca9c4ef)
2. Build failure: Java version errors
   - The default version of java is 8, resulting in errors such as:
     ```
          Exception in thread "main" java.lang.UnsupportedClassVersionError:
          mda/ngchm/datagenerator/ShaidyRMapGen has been compiled by a more
          recent version of the Java Runtime (class file version 55.0), this
          version of the Java Runtime only recognizes class file versions up
          to 52.0
     ```
    - resolution: install java 11 in the workflow (73f9c0e)

Additional changes:

1. Updated documentation to direct users to install:
   - tsvio from CRAN
   - NGCHMSupportFiles from r-universe
   - NGCHMDemoData from r-universe
   - NGCHM from r-universe
   (we had been instructing users to use `remotes::install_github()`) (2e23b86)

