### PR TITLE
Run java headless in system2()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: NGCHM
 Title: Next Generation Clustered Heat Maps
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(
     person(c("Bradley", "M"), "Broom", , "bmbroom@mdanderson.org", role = "aut",
            comment = c(ORCID = "0000-0002-0915-3164")),

--- a/R/functions.R
+++ b/R/functions.R
@@ -3757,8 +3757,7 @@ chmExportToFile <- function(chm, filename, overwrite = FALSE, shaidyMapGen, shai
   shaidyRepo <- ngchm.env$tmpShaidy
   shaid <- shaidyGetShaid(chm)
   status <- system2(shaidyMapGenJava,
-    c(shaidyMapGenArgs, "-jar", shaidyMapGen, shaidyRepo$basepath, shaid@value, shaid@value, "NO_PDF"),
-    env = c("DISPLAY=''")) # Set DISPLAY to empty string to prevent X11 errors in Rstudio Docker container
+    c(shaidyMapGenArgs, "-Djava.awt.headless=true", "-jar", shaidyMapGen, shaidyRepo$basepath, shaid@value, shaid@value, "NO_PDF"))
   if (status != 0) stop("export to ngchm failed")
   if (!file.copy(shaidyRepo$blob.path("viewer", shaid@value, chm@name, paste(chm@name, "ngchm", sep = ".")), filename, TRUE)) {
     stop("export to ngchm failed")
@@ -3814,8 +3813,7 @@ chmExportToPDF <- function(chm, filename, overwrite = FALSE, shaidyMapGen, shaid
   pdfpath <- shaidyRepo$blob.path("viewer", shaid@value, chm@name, paste(chm@name, ".pdf", sep = ""))
   if (!file.exists(pdfpath)) {
     status <- system2(shaidyMapGenJava,
-      c(shaidyMapGenArgs, "-jar", shaidyMapGen, shaidyRepo$basepath, shaid@value, shaid@value),
-      env = c("DISPLAY=''")) # Set DISPLAY to empty string to prevent X11 errors in Rstudio Docker container
+      c(shaidyMapGenArgs, "-Djava.awt.headless=true", "-jar", shaidyMapGen, shaidyRepo$basepath, shaid@value, shaid@value))
     if (status != 0 || !file.exists(pdfpath)) stop("export to pdf failed")
   }
 
@@ -3878,8 +3876,7 @@ chmExportToHTML <- function(chm, filename, overwrite = FALSE, shaidyMapGen, shai
   htmlpath <- shaidyRepo$blob.path("viewer", shaid@value, chm@name, paste(chm@name, ".html", sep = ""))
   if (!file.exists(htmlpath)) {
     status <- system2(shaidyMapGenJava,
-      c(shaidyMapGenArgs, "-jar", shaidyMapGen, shaidyRepo$basepath, shaid@value, shaid@value, "NO_PDF", "-HTML"),
-      env = c("DISPLAY=''")) # Set DISPLAY to empty string to prevent X11 errors in Rstudio Docker container
+      c(shaidyMapGenArgs, "-Djava.awt.headless=true", "-jar", shaidyMapGen, shaidyRepo$basepath, shaid@value, shaid@value, "NO_PDF", "-HTML"))
     if (status != 0 || !file.exists(htmlpath)) stop("export to html failed")
   }
 


### PR DESCRIPTION
To address #51, I had been sending an empty DISPLAY env in system2(). But two things: 1. my syntax was wrong (only Windows complains about it), and 2. it is cleaner to instead run java headless (as pointed out by @ChrisWakefield).

This pull request makes that change: instead of futzing with 'DISPLAY', we send the '-Djava.awt.headless=true' flag in the call to java.

This pull request was motivated by and addresses issue #54, which is a significant bug.

I tested these changes on Windows, Linux (RedHat), MacOS, and the [ngchm/rstudio-ngchm:latest](https://hub.docker.com/r/ngchm/rstudio-ngchm) docker container.