### PR TITLE
Cuts color bug fix

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -3837,8 +3837,8 @@ chmExportToPDF <- function(chm, filename, overwrite = FALSE, shaidyMapGen, shaid
 #' @export
 #' @rdname chmExportToHTML-method
 #'
-#' @param chm The NGCHM to generate the PDF for
-#' @param filename The file in which to save the PDF
+#' @param chm The NGCHM to generate the HTML for
+#' @param filename The file in which to save the HTML
 #' @param overwrite Overwrite file iff true (default false)
 #' @param shaidyMapGen Path to shaidyMapGen jar file (default to value of environment variable SHAIDYMAPGEN)
 #' @param shaidyMapGenJava Path to java executable with which to run shaidyMapGen (default to value of environment variable SHAIDYMAPGENJAVA or java)

--- a/R/functions.R
+++ b/R/functions.R
@@ -581,6 +581,7 @@ chmNewDataLayer <- function(label, data, colors, summarizationMethod, cuts_color
   if (length(cuts_color) != 1) {
     stop(sprintf("Parameter 'cuts_color' must have a single value, not %d", length(cuts_color)))
   }
+  grDevices::col2rgb(cuts_color) # Check that cuts_color is a valid color
   summarizationMethod <- match.arg(summarizationMethod, c("average", "sample", "mode"))
   data <- ngchmSaveAsDatasetBlob(ngchm.env$tmpShaidy, "tsv", data)
   if (length(colors) == 0) {

--- a/man/chmExportToHTML-method.Rd
+++ b/man/chmExportToHTML-method.Rd
@@ -15,9 +15,9 @@ chmExportToHTML(
 )
 }
 \arguments{
-\item{chm}{The NGCHM to generate the PDF for}
+\item{chm}{The NGCHM to generate the HTML for}
 
-\item{filename}{The file in which to save the PDF}
+\item{filename}{The file in which to save the HTML}
 
 \item{overwrite}{Overwrite file iff true (default false)}
 


### PR DESCRIPTION
This PR is related to issue #35. Strictly speaking, the fix is in a PR in the NG-CHM Viewer project: https://github.com/MD-Anderson-Bioinformatics/NG-CHM/pull/541. However, for other color-related variables, the R code checks the validity of the color names so the user is told early on if the name they used is invalid. That check is added here.

Additionally, the low hanging fruit of #29 is addressed.