### PR TITLE
Bug fix for chmAddPCA

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -4022,12 +4022,8 @@ chmAddPCA <- function(hm, axis, prc, basename = "PC", ndim = 2) {
   if (is.null(prc$x)) {
     stop("No principal component coordinates (prc$x) found in the prcomp object.")
   }
-  if (ndim > dim(prc$x)[2]) {
-   stop(paste0("Requested more dimensions than are available in the prcomp object. ",
-              "Requested ", ndim, " dimensions, but only ", dim(prc$x)[2], " are available."))
-  }
 
-  for (idx in 1:ndim) {
+  for (idx in 1:min(ndim, dim(prc$x)[2])) {
     covariate_values = prc$x[, idx]
     # make color map with 3 breakpoints
     minv <- min(covariate_values) # low breakpoint

--- a/R/functions.R
+++ b/R/functions.R
@@ -4001,13 +4001,23 @@ chmAddTSNE <- function(hm, axis, tsne, pointIds, basename = "TSNE") {
 #' @seealso [chmAddReducedDim()]
 
 chmAddPCA <- function(hm, axis, prc, basename = "PC", ndim = 2) {
-  stopifnot(is(hm, "ngchmVersion2"))
-  stopifnot(mode(axis) == "character" && length(axis) == 1)
-  stopifnot(axis == "row" || axis == "column")
-  stopifnot(mode(basename) == "character" && length(basename) == 1)
-  stopifnot(mode(ndim) == "numeric" && length(basename) == 1)
+  if (class(hm) != "ngchmVersion2") {
+    stop("First argument (hm) must be an ngchmVersion2 object.")
+  }
+  if (mode(axis) != "character" || length(axis) != 1) {
+    stop("Second argument (axis) must be a single string.")
+  }
+  if (axis != "column" && axis != "row") {
+    stop("Second argument (axis) must be either 'row' or 'column'.")
+  }
+  if (mode(basename) != "character" || length(basename) != 1) {
+    stop("Fourth argument (basename) must be a single string.")
+  }
+  if (mode(ndim) != "numeric" || length(ndim) != 1) {
+    stop("Fifth argument (ndim) must be a single numeric value.")
+  }
   if (length(class(prc)) != 1 || class(prc) != "prcomp") {
-    stop("Input argument 'prc' must be a prcomp object.")
+    stop("Third argument (prc) must be a prcomp object.")
   }
   if (is.null(prc$x)) {
     stop("No principal component coordinates (prc$x) found in the prcomp object.")

--- a/R/functions.R
+++ b/R/functions.R
@@ -4005,7 +4005,7 @@ chmAddPCA <- function(hm, axis, prc, basename = "PC", ndim = 2) {
     stop("First argument (hm) must be an ngchmVersion2 object.")
   }
   if (mode(axis) != "character" || length(axis) != 1) {
-    stop("Second argument (axis) must be a single string.")
+    stop("Second argument (axis) must be a single string: either 'row' or 'column'.")
   }
   if (axis != "column" && axis != "row") {
     stop("Second argument (axis) must be either 'row' or 'column'.")

--- a/R/functions.R
+++ b/R/functions.R
@@ -4001,7 +4001,7 @@ chmAddTSNE <- function(hm, axis, tsne, pointIds, basename = "TSNE") {
 #' @seealso [chmAddReducedDim()]
 
 chmAddPCA <- function(hm, axis, prc, basename = "PC", ndim = 2) {
-  if (class(hm) != "ngchmVersion2") {
+  if (!is(hm, "ngchmVersion2")) {
     stop("First argument (hm) must be an ngchmVersion2 object.")
   }
   if (mode(axis) != "character" || length(axis) != 1) {


### PR DESCRIPTION
This pull request is a bug fix for issue #67.

Some additional checking of input arguments was also added--for example to check that the third argument is a `prcomp` object and has `prcomp$x`.

Additionally, the existing error checking messages were tweaked to hopefully be slightly easier for users to quickly understand. Example:

If first argument to `chmAddPCA` is not an NG-CHM, the original code gave this error:

```
Error in chmAddPCA();
    is(hm, "ngchmVersion2") is not TRUE
```

I tweaked this slightly to give message:

```
Error in chmAddPCA():
    First argument (hm) must be an ngchmVersion2 object.
```