### PR TITLE
Fixed type separator when adding multiple axis types

### DIFF
--- a/R/allMethods.R
+++ b/R/allMethods.R
@@ -1687,7 +1687,7 @@ setMethod("chmAddAxisType",
   signature = c(chm = "ngchm", where = "character", type = "character", func = "ngchmJS"),
   definition = function(chm, where, type, func) {
     chm <- chmFixVersion(chm)
-    if (length(type) > 1) type <- paste(type, collapse = ".bar.")
+    if (length(type) > 1) type <- paste(type, collapse = ".|.")
     at <- new(Class = "ngchmAxisType", where = where, type = type, func = func)
     chm@axisTypes <- append(chm@axisTypes, at)
     chmAddProperty(chm, paste("!axistype", where, sep = "."), type)


### PR DESCRIPTION
Changed the separator used to join multiple strings in chmAddAxisType from ".bar." to ".|.".

Fixes issue #73.